### PR TITLE
Fix initializer arity

### DIFF
--- a/app/initializers/mixpanel.js
+++ b/app/initializers/mixpanel.js
@@ -1,4 +1,5 @@
-export function initialize(registry, application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
   application.inject('route', 'mixpanel', 'service:mixpanel');
   application.inject('router:main', 'mixpanel', 'service:mixpanel');
   application.inject('controller', 'mixpanel', 'service:mixpanel');


### PR DESCRIPTION
Initializers [now take only a single argument](http://emberjs.com/deprecations/v2.x/#toc_initializer-arity) (the application instance) rather than two. This syntax avoids tripping the deprecation warning, while maintaining backwards compatibility.

If you'd rather have it a bit simpler, you could just use `export function initialize(application) { ...` and drop the backwards compatible syntax.
