### PR TITLE
patch failing initializer test

### DIFF
--- a/tests/unit/initializers/mixpanel-test.js
+++ b/tests/unit/initializers/mixpanel-test.js
@@ -31,7 +31,7 @@ test('initialize', function (assert) {
   const spy = Edgar.createSpy(application, 'inject');
 
   initialize(null, application);
-  assert.equal(spy.called(), 3, 'inject was called 3 times');
+  assert.equal(spy.called(), 4, 'inject was called 4 times');
 });
 
 test('initialize route injection', function (assert) {
@@ -63,6 +63,17 @@ test('initialize controller injection', function (assert) {
 
   let args = spy.calledWith(2);
   assert.equal(args[0], 'controller', 'injected into controllers');
+  assert.equal(args[1], 'mixpanel', 'correct name');
+  assert.equal(args[2], 'service:mixpanel', 'correct registration');
+});
+
+test('initialize component injection', function (assert) {
+  const spy = Edgar.createSpy(application, 'inject');
+
+  initialize(null, application);
+
+  let args = spy.calledWith(3);
+  assert.equal(args[0], 'component', 'injected into controllers');
   assert.equal(args[1], 'mixpanel', 'correct name');
   assert.equal(args[2], 'service:mixpanel', 'correct registration');
 });


### PR DESCRIPTION
I updated the tests to include being testing that the service is injected in components, which fixes the broken test and adds an additional test. I've included a screenshot of the failing test and a screenshot of the passing test.

_Failing Test:_
![failing-test](https://cloud.githubusercontent.com/assets/1318878/12071532/6db51262-b076-11e5-91c3-cd26b8e0db05.jpg)

_Passing Test:_
![passing-test](https://cloud.githubusercontent.com/assets/1318878/12071533/6fffbffe-b076-11e5-8e12-0d66f835160e.jpg)
