### PR TITLE
Add `autoPageviewTracking` config option to toggle auto pageview tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This ember-cli addon injects mixpanel into your ember app.
 
-The mixpanel js is injected into the app's index.html. Pageview tracking is automatic, no mixins required. The mixpanel service is injected into your apps controllers and routes and is available as `this.mixpanel`.
+The mixpanel js is injected into the app's index.html. Pageview tracking is by default automatic, no mixins required. The mixpanel service is injected into your apps controllers and routes and is available as `this.mixpanel`.
 
 This is close port of https://github.com/remerge/ember-cli-mixpanel but refactored as a service.
 
@@ -38,6 +38,7 @@ Add your typekit kitId to `config/environment.js` and you're good to go. A coupl
 ## Configuration Parameters
 
 * `enabled` (Default: `true`): Enable mixpanel tracking
+* `autoPageviewTracking` (Default: `true`): Enable automatic pageview tracking
 * `LOG_EVENT_TRACKING` (Default: `false`): Output logging to the console.
 * `token` (Default: `null`): Mandatory mixpanel api token
 

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -1,14 +1,13 @@
 import Config from '../config/environment';
 
-export function initialize(appInstance) {
+export function initialize(instance) {
   if (Config.mixpanel.enabled) {
-    if (typeof(appInstance.lookup) === 'undefined') {
-      appInstance = appInstance.container;
+    var router = instance.container.lookup('router:main');
+    if (Config.mixpanel.autoPageviewTracking == undefined || Config.mixpanel.autoPageviewTracking) {
+      router.on('didTransition', function() {
+        instance.container.lookup('service:mixpanel').trackPageView(this.get('url'));
+      });
     }
-    let router = appInstance.lookup('router:main');
-    router.on('didTransition', function() {
-      appInstance.lookup('service:mixpanel').trackPageView(this.get('url'));
-    });
   }
 }
 


### PR DESCRIPTION
This is pretty much the same as https://github.com/sportly/ember-cli-mixpanel-service/pull/8 except renamed as `autoPageviewTracking`.
