### PR TITLE
add trackTransitions configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Add your typekit kitId to `config/environment.js` and you're good to go. A coupl
 ## Configuration Parameters
 
 * `enabled` (Default: `true`): Enable mixpanel tracking
+* `trackTransitions` (Default: `true`): automatically track route transitions (also requires `enabled: true`)
 * `LOG_EVENT_TRACKING` (Default: `false`): Output logging to the console.
 * `token` (Default: `null`): Mandatory mixpanel api token
 

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -1,7 +1,11 @@
 import Config from '../config/environment';
 
 export function initialize(appInstance) {
-  if (Config.mixpanel.enabled) {
+  if (Config.mixpanel.trackTransitions == null) {
+    Config.mixpanel.trackTransitions = true;
+  }
+
+  if (Config.mixpanel.enabled && Config.mixpanel.trackTransitions) {
     if (typeof(appInstance.lookup) === 'undefined') {
       appInstance = appInstance.container;
     }


### PR DESCRIPTION
On by default, this allows consuming applications to disable the automatic transition tracking.
