### PR TITLE
Allow users to choose different attribute besides URL for pageview tracking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Add your typekit kitId to `config/environment.js` and you're good to go. A coupl
 
 * `enabled` (Default: `true`): Enable mixpanel tracking
 * `autoPageviewTracking` (Default: `true`): Enable automatic pageview tracking
+* `pageViewAttribute` (Default: `url`): Use some other attribute available to the router instead of `url` for pageview tracking
 * `LOG_EVENT_TRACKING` (Default: `false`): Output logging to the console.
 * `token` (Default: `null`): Mandatory mixpanel api token
 

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -5,7 +5,7 @@ export function initialize(instance) {
     var router = instance.container.lookup('router:main');
     if (Config.mixpanel.autoPageviewTracking == undefined || Config.mixpanel.autoPageviewTracking) {
       router.on('didTransition', function() {
-        instance.container.lookup('service:mixpanel').trackPageView(this.get('url'));
+        instance.container.lookup('service:mixpanel').trackPageView(this.get(Config.mixpanel.pageViewAttribute));
       });
     }
   }


### PR DESCRIPTION
URLs might contain sensitive information in some cases. Therefore, we may not want to send it to a third party tool such as mixpanel. Allowing users to select a different pageview tracking attribute available to the `router` means they don't have to have their own version of instance-initializer.
