### PR TITLE
Allow users to override attributes mixpanel automatically sets for pageview tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Add your typekit kitId to `config/environment.js` and you're good to go. A coupl
 * `enabled` (Default: `true`): Enable mixpanel tracking
 * `autoPageviewTracking` (Default: `true`): Enable automatic pageview tracking
 * `pageViewAttribute` (Default: `url`): Use some other attribute available to the router instead of `url` for pageview tracking
+* `attributeOverrides` (Default: `{}`): Configure overrides, if any, for any of the attributes [mixpanel stores by default](https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default)
 * `LOG_EVENT_TRACKING` (Default: `false`): Output logging to the console.
 * `token` (Default: `null`): Mandatory mixpanel api token
 
@@ -61,9 +62,9 @@ You should add the Mixpanel API to your app's content security policy. To do thi
 
 ### pageviews
 
-`trackPageView: function(page)`
+`trackPageView: function(page, overrides = {})`
 
-Note: Pageviews are tracked automatically, no mixins required.
+Note: Pageviews are tracked automatically, no mixins required. You can override [any properties mixpanel stores by default](https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default) by providing an optional `overrides` object.
 
 ### events
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Add your typekit kitId to `config/environment.js` and you're good to go. A coupl
 
 * `enabled` (Default: `true`): Enable mixpanel tracking
 * `autoPageviewTracking` (Default: `true`): Enable automatic pageview tracking
+* `pageViewAttribute` (Default: `url`): Use some other attribute available to the router instead of `url` for pageview tracking
 * `LOG_EVENT_TRACKING` (Default: `false`): Output logging to the console.
 * `token` (Default: `null`): Mandatory mixpanel api token
 

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -5,7 +5,7 @@ export function initialize(instance) {
     var router = instance.container.lookup('router:main');
     if (Config.mixpanel.autoPageviewTracking == undefined || Config.mixpanel.autoPageviewTracking) {
       router.on('didTransition', function() {
-        instance.container.lookup('service:mixpanel').trackPageView(this.get('url'));
+        instance.container.lookup('service:mixpanel').trackPageView(this.get(Config.mixpanel.pageViewAttribute));
       });
     }
   }

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -5,7 +5,8 @@ export function initialize(instance) {
     var router = instance.container.lookup('router:main');
     if (Config.mixpanel.autoPageviewTracking == undefined || Config.mixpanel.autoPageviewTracking) {
       router.on('didTransition', function() {
-        instance.container.lookup('service:mixpanel').trackPageView(this.get(Config.mixpanel.pageViewAttribute));
+        var attributeOverrides = Config.mixpanel.attributeOverrides || {};
+        instance.container.lookup('service:mixpanel').trackPageView(this.get(Config.mixpanel.pageViewAttribute), attributeOverrides);
       });
     }
   }

--- a/app/services/mixpanel.js
+++ b/app/services/mixpanel.js
@@ -14,14 +14,14 @@ export default Ember.Service.extend({
         Ember.Logger.info('[Mixpanel] ', arguments);
     },
 
-    trackPageView: function(page) {
+    trackPageView: function(page, overrides = {}) {
         if (this.pageHasAnalytics()) {
             if (!page) {
                 var loc = window.location;
                 page = loc.hash ? loc.hash.substring(1) : loc.pathname + loc.search;
             }
 
-            window.mixpanel.track("visit", {pageName: page});
+            window.mixpanel.track("visit", Object.assign({pageName: page}, overrides));
         }
 
         if (this.logTrackingEnabled()) {


### PR DESCRIPTION
Mixpanel stores `$current_url` and many other properties by default. The full list can be found over at https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default. This allows users to disable URL tracking by passing overrides to `pageViewTracking`. It also makes the overrides configurable. The reason for this change is that URLs might contain sensitive information that people do not want to send over to mixpanel.

This should be reviewed after https://github.com/sportly/ember-cli-mixpanel-service/pull/16. I opened separate PRs because the two, while dependent, seemed different concerns.
