### PR TITLE
Use Ember.merge instead of Object.assign

### DIFF
--- a/app/services/mixpanel.js
+++ b/app/services/mixpanel.js
@@ -21,7 +21,7 @@ export default Ember.Service.extend({
                 page = loc.hash ? loc.hash.substring(1) : loc.pathname + loc.search;
             }
 
-            window.mixpanel.track("visit", Object.assign({pageName: page}, overrides));
+            window.mixpanel.track("visit", Ember.merge({pageName: page}, overrides));
         }
 
         if (this.logTrackingEnabled()) {


### PR DESCRIPTION
`Object.assign` is breaking a [prerender](https://github.com/prerender/prerender) server that I'm running, which uses phantomjs. Phantomjs doesn't support `Object.assign` so it seems easier to just use `Ember.merge` instead.
