### PR TITLE
Set defaults with a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ More on mixpanel at http://www.mixpanel.com
 ## Installation
 
 ```
-ember install:addon ember-cli-mixpanel-service
+ember install ember-cli-mixpanel-service
 ```
 
 # Configuration

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,0 +1,103 @@
+import Ember from 'ember';
+
+const { getWithDefault } = Ember;
+
+const DEFAULTS = {
+    enabled: true,
+    autoPageviewTracking: false,
+    pageViewAttribute: 'url',
+    attributeOverrides: {},
+    LOG_EVENT_TRACKING: false,
+    token: null
+};
+
+/**
+    ember-cli-mixpanel-service's configuration object.
+
+    To change any of these values, set them on the application's environment
+    object, e.g.:
+
+    ```js
+    // config/environment.js
+    ENV['mixpanel'] = {
+      token: 'abcd123456789'
+    };
+    ```
+
+    @class Configuration
+    @extends Object
+    @module ember-cli-mixpanel-service/configuration
+    @public
+*/
+export default {
+    /**
+      Enable mixpanel tracking.
+
+      @property enabled
+      @readOnly
+      @static
+      @type boolean
+      @default true
+      @public
+    */
+    enabled: DEFAULTS.enabled,
+
+    /**
+      Enable automatic pageview tracking
+
+      @property autoPageviewTracking
+      @readOnly
+      @static
+      @type boolean
+      @default false
+      @public
+    */
+    autoPageviewTracking: DEFAULTS.autoPageviewTracking,
+
+    /**
+      Use some other attribute available to the router instead of url for pageview tracking
+
+      @property pageViewAttribute
+      @readOnly
+      @static
+      @type String
+      @default 'url'
+      @public
+    */
+
+    pageViewAttribute: DEFAULTS.pageViewAttribute,
+
+
+    /**
+      Configure overrides, if any, for any of the attributes mixpanel stores by default
+
+      @property attributeOverrides
+      @readOnly
+      @static
+      @type Object
+      @default {}
+      @public
+    */
+
+    attributeOverrides: DEFAULTS.attributeOverrides,
+
+    /**
+      Output logging to the console.
+
+      @property LOG_EVENT_TRACKING
+      @readOnly
+      @static
+      @type boolean
+      @default false
+      @public
+    */
+    LOG_EVENT_TRACKING: DEFAULTS.LOG_EVENT_TRACKING,
+
+    load(config) {
+        for (let property in this) {
+            if (this.hasOwnProperty(property) && Ember.typeOf(this[property]) !== 'function') {
+                this[property] = getWithDefault(config, property, DEFAULTS[property]);
+              }
+        }
+    }
+};

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -4,7 +4,7 @@ const { getWithDefault } = Ember;
 
 const DEFAULTS = {
     enabled: true,
-    autoPageviewTracking: false,
+    autoPageviewTracking: true,
     pageViewAttribute: 'url',
     attributeOverrides: {},
     LOG_EVENT_TRACKING: false,

--- a/app/initializers/mixpanel.js
+++ b/app/initializers/mixpanel.js
@@ -1,12 +1,16 @@
-export function initialize() {
-  let application = arguments[1] || arguments[0];
-  application.inject('route', 'mixpanel', 'service:mixpanel');
-  application.inject('router:main', 'mixpanel', 'service:mixpanel');
-  application.inject('controller', 'mixpanel', 'service:mixpanel');
-  application.inject('component', 'mixpanel', 'service:mixpanel');
-}
+import ENV from '../config/environment';
+import Configuration from 'ember-cli-mixpanel-service/configuration';
 
 export default {
-  name: 'mixpanel',
-  initialize: initialize
+    name: 'mixpanel',
+    initialize: function() {
+        const config = ENV['mixpanel'] || {};
+        Configuration.load(config);
+
+        let application = arguments[1] || arguments[0];
+        application.inject('route', 'mixpanel', 'service:mixpanel');
+        application.inject('router:main', 'mixpanel', 'service:mixpanel');
+        application.inject('controller', 'mixpanel', 'service:mixpanel');
+        application.inject('component', 'mixpanel', 'service:mixpanel');
+    }
 };

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -1,7 +1,7 @@
-import Config from '../config/environment';
+import Configuration from 'ember-cli-mixpanel-service/configuration';
 
 export function initialize(instance) {
-  if (Config.mixpanel.enabled) {
+  if (Configuration.enabled) {
     let router;
     if (typeof instance.lookup === 'function') {
       router = instance.lookup('router:main');
@@ -9,19 +9,17 @@ export function initialize(instance) {
       router = instance.container.lookup('router:main');
     }
 
-    if (Config.mixpanel.autoPageviewTracking == undefined || Config.mixpanel.autoPageviewTracking) {
-      router.on('didTransition', function() {
-        var attributeOverrides = Config.mixpanel.attributeOverrides || {};
-        let mixpanelService;
-        if (typeof instance.lookup === 'function') {
-          mixpanelService = instance.lookup('service:mixpanel');
-        } else {
-          mixpanelService = instance.container.lookup('service:mixpanel');
-        }
-        let pageViewAttribute = Config.mixpanel.pageViewAttribute || 'url';
-        mixpanelService.trackPageView(this.get(pageViewAttribute), attributeOverrides);
-      });
-    }
+    router.on('didTransition', function() {
+      var attributeOverrides = Configuration.attributeOverrides;
+      let mixpanelService;
+      if (typeof instance.lookup === 'function') {
+        mixpanelService = instance.lookup('service:mixpanel');
+      } else {
+        mixpanelService = instance.container.lookup('service:mixpanel');
+      }
+      let pageViewAttribute = Configuration.pageViewAttribute;
+      mixpanelService.trackPageView(this.get(pageViewAttribute), attributeOverrides);
+    });
   }
 }
 

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -9,17 +9,19 @@ export function initialize(instance) {
       router = instance.container.lookup('router:main');
     }
 
-    router.on('didTransition', function() {
-      var attributeOverrides = Configuration.attributeOverrides;
-      let mixpanelService;
-      if (typeof instance.lookup === 'function') {
-        mixpanelService = instance.lookup('service:mixpanel');
-      } else {
-        mixpanelService = instance.container.lookup('service:mixpanel');
-      }
-      let pageViewAttribute = Configuration.pageViewAttribute;
-      mixpanelService.trackPageView(this.get(pageViewAttribute), attributeOverrides);
-    });
+    if (Configuration.autoPageviewTracking == undefined || Configuration.autoPageviewTracking) {
+      router.on('didTransition', function() {
+        var attributeOverrides = Configuration.attributeOverrides;
+        let mixpanelService;
+        if (typeof instance.lookup === 'function') {
+          mixpanelService = instance.lookup('service:mixpanel');
+        } else {
+          mixpanelService = instance.container.lookup('service:mixpanel');
+        }
+        let pageViewAttribute = Configuration.pageViewAttribute;
+        mixpanelService.trackPageView(this.get(pageViewAttribute), attributeOverrides);
+      });
+    }
   }
 }
 

--- a/app/services/mixpanel.js
+++ b/app/services/mixpanel.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
-import Config from '../config/environment';
+import Configuration from 'ember-cli-mixpanel-service/configuration';
 
 export default Ember.Service.extend({
     pageHasAnalytics: function() {
-        return window.mixpanel && typeof window.mixpanel === "object" && Config.mixpanel.enabled;
+        return window.mixpanel && typeof window.mixpanel === "object" && Configuration.enabled;
     },
 
     logTrackingEnabled: function() {
-        return !!Config && !! Config.mixpanel.LOG_EVENT_TRACKING;
+        return !!Configuration && !! Configuration.LOG_EVENT_TRACKING;
     },
 
     logTracking: function() {


### PR DESCRIPTION
**Done in this PR:**
- Update `install` command on `README.md`;
- When I did not have `enabled: true` on my `config/environment.js` file, the addon was not being loaded, even though you say that `enabled` is `true` by default. This PR includes a `configuration.js` file where all the defaults needed are loaded when initializing the app. 
